### PR TITLE
Migrate /opt/node -> /opt/iojs

### DIFF
--- a/ubuntu/iojs-lucid/Dockerfile
+++ b/ubuntu/iojs-lucid/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:precise
+FROM ubuntu:lucid
 
+RUN uname -a
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --force-yes build-essential python-all curl python-software-properties
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update && apt-get -y --force-yes install gcc-4.8 g++-4.8
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 RUN adduser node-forward --disabled-password --gecos 'Node Forward'
 
-VOLUME [ "/opt/node/" ]
+VOLUME [ "/opt/iojs/" ]
 
-CMD su node-forward -c 'cd /opt/node/ && make clean && ./configure && make -j8 && make test-simple'
+CMD su node-forward -c 'cd /opt/iojs/ && make clean && ./configure && make -j8 && make test-simple'

--- a/ubuntu/iojs-precise/Dockerfile
+++ b/ubuntu/iojs-precise/Dockerfile
@@ -1,14 +1,13 @@
-FROM ubuntu:lucid
+FROM ubuntu:precise
 
-RUN uname -a
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --force-yes build-essential python-all curl python-software-properties
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update && apt-get -y --force-yes install gcc-4.8 g++-4.8
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50 && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 RUN adduser node-forward --disabled-password --gecos 'Node Forward'
 
-VOLUME [ "/opt/node/" ]
+VOLUME [ "/opt/iojs/" ]
 
-CMD su node-forward -c 'cd /opt/node/ && make clean && ./configure && make -j8 && make test-simple'
+CMD su node-forward -c 'cd /opt/iojs/ && make clean && ./configure && make -j8 && make test-simple'

--- a/ubuntu/iojs-trusty/Dockerfile
+++ b/ubuntu/iojs-trusty/Dockerfile
@@ -5,6 +5,6 @@ RUN apt-get install -y --force-yes build-essential python-all curl
 
 RUN adduser node-forward --disabled-password --gecos 'Node Forward'
 
-VOLUME [ "/opt/node/" ]
+VOLUME [ "/opt/iojs/" ]
 
-CMD su node-forward -c 'cd /opt/node/ && make clean && ./configure && make -j8 && make test-simple'
+CMD su node-forward -c 'cd /opt/iojs/ && make clean && ./configure && make -j8 && make test-simple'


### PR DESCRIPTION
ATM, this is the only safe change that can be made. My guess is that your user in jenkins machine is called `node-forward`, am I right @rvagg? That's the only reason I can find the bind-mount of volumes is not giving issues.
