### PR TITLE
Add gcc 4.9 to Debian Stable using Jessie

### DIFF
--- a/debian/iojs-stable/Dockerfile
+++ b/debian/iojs-stable/Dockerfile
@@ -2,11 +2,16 @@ FROM debian:stable
 ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo 'deb http://http.debian.net/debian/ jessie main non-free contrib' >> /etc/apt/sources.list
+
+ADD apt-preferences /etc/apt/preferences
+
 RUN apt-get update && \
     apt-get install -y --force-yes \
-      build-essential \
-      python-all \
-      curl && \
+      gcc g++ cpp g++-4.9 gcc-4.9 cpp-4.9 libstdc++-4.9-dev libcloog-isl4 libmpc3 \
+      libgcc-4.9-dev libatomic1 libcilkrts5 libc6 libc6-dev libc-dev-bin && \
+    apt-get install -y --force-yes \
+      make python-all curl && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd iojs && \

--- a/debian/iojs-stable/Dockerfile
+++ b/debian/iojs-stable/Dockerfile
@@ -2,16 +2,20 @@ FROM debian:stable
 ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo 'deb http://http.debian.net/debian/ jessie main non-free contrib' >> /etc/apt/sources.list
-
-ADD apt-preferences /etc/apt/preferences
+RUN apt-get update && \
+    apt-get install -y --force-yes \
+      apt-transport-https curl && \
+    echo 'deb https://deb.nodesource.com/weezy-gcc49 weezy-gcc49 main' >> /etc/apt/sources.list && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && \
     apt-get install -y --force-yes \
-      gcc g++ cpp g++-4.9 gcc-4.9 cpp-4.9 libstdc++-4.9-dev libcloog-isl4 libmpc3 \
-      libgcc-4.9-dev libatomic1 libcilkrts5 libc6 libc6-dev libc-dev-bin && \
-    apt-get install -y --force-yes \
-      make python-all curl && \
+      g++-4.9 gcc-4.9 cpp-4.9 \
+      make python-all && \
+    ln -sf /usr/bin/gcc-4.9 /usr/bin/gcc && \
+    ln -sf /usr/bin/gcc-4.9 /usr/bin/cc && \
+    ln -sf /usr/bin/g++-4.9 /usr/bin/g++ && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd iojs && \

--- a/debian/iojs-stable/apt-preferences
+++ b/debian/iojs-stable/apt-preferences
@@ -1,7 +1,0 @@
-Package: *
-Pin: release n=wheezy
-Pin-Priority: 900
-
-Package: cpp gcc g++ g++-4.9 gcc-4.9 libc6 libmpfr4 binutils libisl10 libgcc1 libgomp1 libitm1 libquadmath0 libstdc++6 libc-dev libc6-dev libc-dev-bin
-Pin: release n=jessie
-Pin-Priority: 910

--- a/debian/iojs-stable/apt-preferences
+++ b/debian/iojs-stable/apt-preferences
@@ -1,0 +1,7 @@
+Package: *
+Pin: release n=wheezy
+Pin-Priority: 900
+
+Package: cpp gcc g++ g++-4.9 gcc-4.9 libc6 libmpfr4 binutils libisl10 libgcc1 libgomp1 libitm1 libquadmath0 libstdc++6 libc-dev libc6-dev libc-dev-bin
+Pin: release n=jessie
+Pin-Priority: 910


### PR DESCRIPTION
We need a newer gcc than ships with Debian stable and the best option I can come up with is to pull 4.9 from Jessie which also means pulling in additional dependencies _including_ a newer libc. This container now builds io.js/v0.12 but I'm wavering because it's almost not Debian stable anymore since we're upgrading core components.

Thoughts & review please @ghostbar & @wblankenship 