### PR TITLE
`s/-j8/-j4` for build parallelisation

### DIFF
--- a/debian/iojs-stable/Dockerfile
+++ b/debian/iojs-stable/Dockerfile
@@ -29,5 +29,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/iojs && \
       make clean && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make test-simple'

--- a/debian/iojs-testing/Dockerfile
+++ b/debian/iojs-testing/Dockerfile
@@ -20,5 +20,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/iojs && \
       make clean && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make test-simple'

--- a/debian/libuv-stable/Dockerfile
+++ b/debian/libuv-stable/Dockerfile
@@ -22,5 +22,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/libuv && \
       sh autogen.sh && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make check'

--- a/debian/libuv-testing/Dockerfile
+++ b/debian/libuv-testing/Dockerfile
@@ -22,5 +22,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/libuv && \
       sh autogen.sh && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make check'

--- a/ubuntu/iojs-lucid/Dockerfile
+++ b/ubuntu/iojs-lucid/Dockerfile
@@ -29,5 +29,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/iojs && \
       make clean && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make test-simple'

--- a/ubuntu/iojs-precise/Dockerfile
+++ b/ubuntu/iojs-precise/Dockerfile
@@ -30,5 +30,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/iojs && \
       make clean && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make test-simple'

--- a/ubuntu/iojs-trusty/Dockerfile
+++ b/ubuntu/iojs-trusty/Dockerfile
@@ -19,5 +19,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/iojs && \
       make clean && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make test-simple'

--- a/ubuntu/libuv-lucid/Dockerfile
+++ b/ubuntu/libuv-lucid/Dockerfile
@@ -21,5 +21,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/libuv && \
       sh autogen.sh && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make check'

--- a/ubuntu/libuv-precise/Dockerfile
+++ b/ubuntu/libuv-precise/Dockerfile
@@ -21,5 +21,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/libuv && \
       sh autogen.sh && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make check'

--- a/ubuntu/libuv-trusty/Dockerfile
+++ b/ubuntu/libuv-trusty/Dockerfile
@@ -21,5 +21,5 @@ CMD mkdir /build && \
     su iojs -c 'cd /build/libuv && \
       sh autogen.sh && \
       ./configure && \
-      make -j8 && \
+      make -j4 && \
       make check'


### PR DESCRIPTION
Because we're running all of these together, currently over 2 8-core machines but as we increase the number of containers we'll have to balance the number of machines to the build parallelisation. I think that currently 4 is a good compromise between our needs and making these containers useful to others, 8 is just too much.